### PR TITLE
Fix cameraView is gone when the app enter background bug

### DIFF
--- a/ApiLocalStorageVideoRecorder.xcodeproj/project.pbxproj
+++ b/ApiLocalStorageVideoRecorder.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Players;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportsDocumentBrowser = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -468,7 +468,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Players;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportsDocumentBrowser = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ApiLocalStorageVideoRecorder/AppDelegate.swift
+++ b/ApiLocalStorageVideoRecorder/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         
+        /// To test CoreData without deleting the app
 //        let coreDataManager = CoreDataManager()
 //        coreDataManager.deleteAllPlayers()
         

--- a/ApiLocalStorageVideoRecorder/Pages/Players/Cells/PlayersTableViewCell.swift
+++ b/ApiLocalStorageVideoRecorder/Pages/Players/Cells/PlayersTableViewCell.swift
@@ -17,8 +17,6 @@ class PlayersTableViewCell: UITableViewCell {
 
     @IBOutlet weak var shotLabel: UILabel!
     @IBOutlet weak var nameLabel: UILabel!
-    @IBOutlet weak var surnameLabel: UILabel!
-    
     @IBOutlet weak var avatarInitialLabel: UILabel!
     @IBOutlet weak var playerView: UIView!
     @IBOutlet weak var shotView: UIView!

--- a/ApiLocalStorageVideoRecorder/Pages/Players/PlayersViewController.swift
+++ b/ApiLocalStorageVideoRecorder/Pages/Players/PlayersViewController.swift
@@ -14,8 +14,6 @@ class PlayersViewController: UIViewController {
     @IBOutlet weak var playersLabel: UILabel!
     @IBOutlet weak var shotsLabel: UILabel!
     
-    
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()

--- a/ApiLocalStorageVideoRecorder/SceneDelegate.swift
+++ b/ApiLocalStorageVideoRecorder/SceneDelegate.swift
@@ -8,48 +8,51 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
-
+    
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
-
+        if let rootViewController = window?.rootViewController as? UINavigationController {
+            rootViewController.popToRootViewController(animated: false)
+        }
+        
         // Save changes in the application's managed object context when the application transitions to the background.
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
-
-
+    
+    
 }
 


### PR DESCRIPTION
Added 
```
 if let rootViewController = window?.rootViewController as? UINavigationController {
            rootViewController.popToRootViewController(animated: false)
        }
```
On  func sceneDidEnterBackground(_ scene: UIScene) { }